### PR TITLE
Fix py3.9 type hint causing failure in py3.8

### DIFF
--- a/Cogs/Xkcd.py
+++ b/Cogs/Xkcd.py
@@ -1,5 +1,5 @@
 from random import randint
-from typing import Optional, Union, Callable
+from typing import Optional, List, Callable
 
 from discord import Embed
 from discord.ext import commands
@@ -8,7 +8,7 @@ from discord.ext.commands import Context
 
 
 class Xkcd(commands.Cog):
-    required_response_fields: list[str] = ['year', 'month', 'day', 'alt', 'num']
+    required_response_fields: List[str] = ['year', 'month', 'day', 'alt', 'num']
     theme_color: int = 0x7610ba
 
     def __init__(self, bot):

--- a/robot.py
+++ b/robot.py
@@ -24,7 +24,8 @@ cogs = [
     "Cogs.Colors",
     "Cogs.MAL",
     "Cogs.Economy",
-    "Cogs.Trivia"
+    "Cogs.Trivia",
+    "Cogs.Xkcd"
 ]
 
 


### PR DESCRIPTION
Was using native type hinting feature introduced in python 3.9, but rikka-bot uses python 3.8.10, which was causing a interpreter failure.